### PR TITLE
Register as a service so it can be injected at will

### DIFF
--- a/addon/initializers/parse-auth.js
+++ b/addon/initializers/parse-auth.js
@@ -118,11 +118,11 @@ export function initialize(container, application) {
 
 
   });
-  application.register('parse-auth:main', authObject);
-  application.inject('route', 'parseAuth', 'parse-auth:main');
-  application.inject('controller', 'parseAuth', 'parse-auth:main');
-  application.inject('component', 'parseAuth', 'parse-auth:main');
-  application.inject('view', 'parseAuth', 'parse-auth:main');
+  application.register('service:parse-auth', authObject);
+  application.inject('route', 'parseAuth', 'service:parse-auth');
+  application.inject('controller', 'parseAuth', 'service:parse-auth');
+  application.inject('component', 'parseAuth', 'service:parse-auth');
+  application.inject('view', 'parseAuth', 'service:parse-auth');
 }
 
 export default {

--- a/app/instance-initializers/parse-auth.js
+++ b/app/instance-initializers/parse-auth.js
@@ -6,7 +6,7 @@ export default {
     //after: '',
     initialize: function(instance) {
         Parse.initialize(config.parse.appId, config.parse.javascriptKey);
-        var pa = instance.container.lookup("parse-auth:main");
+        var pa = instance.container.lookup("service:parse-auth");
         pa.register_instance(instance);
 
         if (!navigator.userAgent.match(/(iPhone|iPod|iPad|Android|BlackBerry|IEMobile)/) || typeof facebookConnectPlugin === "undefined") {


### PR DESCRIPTION
Changed the name of of the parseAuth mechanism to service:parse-auth so that it can be injected on demand into ember objects of any kind.
